### PR TITLE
Fix local development on macOS

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+LOCAL_PORT = 5555

--- a/tests/test_s3_loader.py
+++ b/tests/test_s3_loader.py
@@ -12,6 +12,7 @@ from thumbor.loaders import LoaderResult
 from tornado.testing import gen_test
 
 from .fixtures.storage_fixture import IMAGE_PATH, IMAGE_BYTES, s3_bucket
+from .fixtures import LOCAL_PORT
 from tc_aws.loaders import s3_loader
 from tests import S3MockedAsyncTestCase
 
@@ -20,7 +21,7 @@ class S3LoaderTestCase(S3MockedAsyncTestCase):
 
     @gen_test
     async def test_can_load_image(self):
-        client = botocore.session.get_session().create_client('s3', endpoint_url='http://localhost:5000')
+        client = botocore.session.get_session().create_client('s3', endpoint_url=f'http://localhost:{LOCAL_PORT}')
 
         client.put_object(
             Bucket=s3_bucket,


### PR DESCRIPTION
Since macOS Monterey in 2001, the Control Center service has been using port 5000 at startup[1], meaning that the moto test server will be binding to an already-in-use port and silently fail, causing most tests to fail with a somewhat inexplicable 403 Forbidden.

This fixes that by making the port a fixture in tests/fixtures and using that constant anywhere the test code was using port 5000.

[1] https://medium.com/pythonistas/port-5000-already-in-use-macos-monterey-issue-d86b02edd36c